### PR TITLE
Arduino Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,9 @@ docs/_build/
 target/
 dump.rdb
 
-# made by jgonzal 
+# made by jgonzal
 controller.py
 
 Dator/db.sqlite3
+workspace/src/barc/rosbag/
+*.ropeproject/

--- a/arduino/arduino_nano328_node/arduino_nano328_node.ino
+++ b/arduino/arduino_nano328_node/arduino_nano328_node.ino
@@ -57,10 +57,10 @@ class Car {
     void calcSteering();
   private:
     // Pin assignments
-    /* const int ENC_FR_PIN = X; */
     const int ENC_FL_PIN = 2;
-    const int ENC_BR_PIN = 3;
+    const int ENC_FR_PIN = 3;
     const int ENC_BL_PIN = 5;
+    const int ENC_BR_PIN = 6;
     const int THROTTLE_PIN = 7;
     const int STEERING_PIN = 8;
     const int MOTOR_PIN = 10;
@@ -275,11 +275,11 @@ float Car::saturateServo(float x) {
 }
 
 void Car::initEncoders() {
-  /* pinMode(ENC_FR_PIN, INPUT_PULLUP); */
+  pinMode(ENC_FR_PIN, INPUT_PULLUP);
   pinMode(ENC_FL_PIN, INPUT_PULLUP);
   pinMode(ENC_BR_PIN, INPUT_PULLUP);
   pinMode(ENC_BL_PIN, INPUT_PULLUP);
-  /* enableInterrupt(ENC_FR_PIN, incFRCallback, CHANGE); */
+  enableInterrupt(ENC_FR_PIN, incFRCallback, CHANGE);
   enableInterrupt(ENC_FL_PIN, incFLCallback, CHANGE);
   enableInterrupt(ENC_BR_PIN, incBRCallback, CHANGE);
   enableInterrupt(ENC_BL_PIN, incBLCallback, CHANGE);

--- a/arduino/arduino_nano328_node/arduino_nano328_node.ino
+++ b/arduino/arduino_nano328_node/arduino_nano328_node.ino
@@ -8,7 +8,8 @@
 # at UC Berkeley in the Model Predictive Control (MPC) lab by Jon Gonzales
 # (jon.gonzales@berkeley.edu)  Development of the web-server app Dator was
 # based on an open source project by Bruce Wootton, with contributions from
-# Kiet Lam (kiet.lam@berkeley.edu)
+# Kiet Lam (kiet.lam@berkeley.edu). The RC Input code was based on sample code
+# from http://rcarduino.blogspot.com/2012/04/how-to-read-multiple-rc-channels-draft.html
 # --------------------------------------------------------------------------- */
 
 
@@ -18,7 +19,6 @@ WARNING:
   some float voltage
 # --------------------------------------------------------------------------- */
 
-
 // include libraries
 #include <ros.h>
 #include <barc/Ultrasound.h>
@@ -26,68 +26,155 @@ WARNING:
 #include <barc/ECU.h>
 #include <Servo.h>
 #include "Maxbotix.h"
+#include <EnableInterrupt.h>
 
-// Number of encoder counts on tires
-// count tick on {FL, FR, BL, BR}
-// F = front, B = back, L = left, R = right
-volatile int FL_count = 0;
-volatile int FR_count = 0;
+/**************************************************************************
+CAR CLASS DEFINITION (would like to refactor into car.cpp and car.h but can't figure out arduino build process so far)
+**************************************************************************/
+class Car {
+  public:
+    void initEncoders();
+    void initRCInput();
+    void initActuators();
+    void armActuators();
+    void writeToActuators(const barc::ECU& ecu);
+    // Used for copying variables shared with interrupts to avoid read/write
+    // conflicts later
+    void readAndCopyInputs();
+    // Getters
+    uint8_t getRCThrottle();
+    uint8_t getRCSteering();
+    int getEncoderFL();
+    int getEncoderFR();
+    int getEncoderBL();
+    int getEncoderBR();
+    // Interrupt service routines
+    void incFR();
+    void incFL();
+    void incBR();
+    void incBL();
+    void calcThrottle();
+    void calcSteering();
+  private:
+    // Pin assignments
+    /* const int ENC_FR_PIN = X; */
+    const int ENC_FL_PIN = 2;
+    const int ENC_BR_PIN = 3;
+    const int ENC_BL_PIN = 5;
+    const int THROTTLE_PIN = 7;
+    const int STEERING_PIN = 8;
+    const int MOTOR_PIN = 10;
+    const int SERVO_PIN= 11;
 
-//encoder pins: pins 2,3 are hardware interrupts
-const int encPinA = 2;
-const int encPinB = 3;
+    // Car properties
+    // unclear what this is for
+    const int noAction = 0;
 
-// Actuator pins: 5,6
-// <Servo> data type performs PWM
-// Declare variables to hold actuator commands
-Servo motor;
-Servo steering;
-const int motorPin = 10;
-const int servoPin = 11;
-int motorCMD;
-int servoCMD;
-const int noAction = 0;
+    // Motor limits
+    // TODO are these the real limits?
+    const int MOTOR_MAX = 120;
+    const int MOTOR_MIN = 40;
+    const int MOTOR_NEUTRAL = 90;
+    // Optional: smaller values for testing safety
+    /* const int MOTOR_MAX = 100; */
+    /* const int MOTOR_MIN = 75; */
 
-// Actuator constraints (servo)
-// Not sure if constraints should be active on motor as well
-int d_theta_max = 50;
-int theta_center = 90;
-int motor_neutral = 90;
-int theta_max = theta_center + d_theta_max;
-int theta_min = theta_center - d_theta_max;
-int motor_max = 120;
-int motor_min = 40;
+    // Steering limits
+    // TODO seems to me that the permissible steering range is really about [58,
+    // 120] judging from the sound of the servo pushing beyond a mechanical limit
+    // outside that range. The offset may be 2 or 3 deg and the d_theta_max is then
+    // ~31.
+    const int D_THETA_MAX = 30;
+    const int THETA_CENTER = 90;
+    const int THETA_MAX = THETA_CENTER + D_THETA_MAX;
+    const int THETA_MIN = THETA_CENTER - D_THETA_MAX;
 
-// variable for time
+    // Interfaces to motor and steering actuators
+    Servo motor;
+    Servo steering;
+
+    // Utility variables to handle RC and encoder inputs
+    volatile uint8_t updateFlagsShared;
+    uint8_t updateFlags;
+    const int THROTTLE_FLAG = 1;
+    const int STEERING_FLAG = 2;
+    const int FL_FLAG = 3;
+    const int FR_FLAG = 4;
+    const int BL_FLAG = 5;
+    const int BR_FLAG = 6;
+
+    uint32_t throttleStart;
+    uint32_t steeringStart;
+    volatile uint16_t throttleInShared;
+    volatile uint16_t steeringInShared;
+    uint16_t throttleIn = 1500;
+    uint16_t steeringIn = 1500;
+
+    // Number of encoder counts on tires
+    // count tick on {FL, FR, BL, BR}
+    // F = front, B = back, L = left, R = right
+    volatile int FL_count_shared = 0;
+    volatile int FR_count_shared = 0;
+    volatile int BL_count_shared = 0;
+    volatile int BR_count_shared = 0;
+    int FL_count = 0;
+    int FR_count = 0;
+    int BL_count = 0;
+    int BR_count = 0;
+
+    // Utility functions
+    uint8_t microseconds2PWM(uint16_t microseconds);
+    float saturateMotor(float x);
+    float saturateServo(float x);
+};
+
+// Initialize an instance of the Car class as car
+Car car;
+
+// Callback Functions
+// These are really sad solutions to the fact that using class member functions
+// as callbacks is complicated in C++ and I haven't figured it out. If you can
+// figure it out, please atone for my sins.
+void ecuCallback(const barc::ECU& ecu) {
+  car.writeToActuators(ecu);
+}
+void incFLCallback() {
+  car.incFL();
+}
+void incFRCallback() {
+  car.incFR();
+}
+void incBLCallback() {
+  car.incBL();
+}
+void incBRCallback() {
+  car.incBR();
+}
+void calcSteeringCallback() {
+  car.calcSteering();
+}
+void calcThrottleCallback() {
+  car.calcThrottle();
+}
+
+// Variables for time step
 volatile unsigned long dt;
 volatile unsigned long t0;
 
+// Global message variables
+// Encoder, RC Inputs, Electronic Control Unit, Ultrasound
+barc::ECU ecu;
+barc::ECU rc_inputs;
+barc::Encoder encoder;
+barc::Ultrasound ultrasound;
+
 ros::NodeHandle nh;
 
-// define global message variables
-// Encoder, Electronic Control Unit, Ultrasound
-barc::Ultrasound ultrasound;
-barc::ECU ecu;
-barc::Encoder encoder;
-
 ros::Publisher pub_encoder("encoder", &encoder);
+ros::Publisher pub_rc_inputs("rc_inputs", &rc_inputs);
 ros::Publisher pub_ultrasound("ultrasound", &ultrasound);
+ros::Subscriber<barc::ECU> sub_ecu("ecu", ecuCallback);
 
-
-/**************************************************************************
-ESC COMMAND {MOTOR, SERVO} CALLBACK
-**************************************************************************/
-void messageCb(const barc::ECU& ecu){
-  // deconstruct esc message
-  motorCMD = saturateMotor( int(ecu.motor_pwm) );
-  servoCMD = saturateServo( int(ecu.servo_pwm) );
-
-  // apply commands to motor and servo
-  motor.write( motorCMD );
-  steering.write(  servoCMD );
-}
-// ECU := Engine Control Unit
-ros::Subscriber<barc::ECU> s("ecu", messageCb);
 
 // Set up ultrasound sensors
 /*
@@ -102,28 +189,22 @@ ARDUINO INITIALIZATION
 **************************************************************************/
 void setup()
 {
-  // Set up encoder sensors
-  pinMode(encPinA, INPUT_PULLUP);
-  pinMode(encPinB, INPUT_PULLUP);
-  attachInterrupt(0, FL_inc, CHANGE); // args = (digitalPintoInterrupt, ISR, mode), mode set = {LOW, CHANGE, RISING, FALLING}, pin 0 = INT0, which is pin D2
-  attachInterrupt(1, FR_inc, CHANGE); //pin 1 = INT1, which is pin D3
+  // Set up encoders, rc input, and actuators
+  car.initEncoders();
+  car.initRCInput();
+  car.initActuators();
 
-  // Set up actuators
-  motor.attach(motorPin);
-  steering.attach(servoPin);
-
-    // Start ROS node
+  // Start ROS node
   nh.initNode();
 
-  // Publish / Subscribe to topics
-  nh.advertise(pub_ultrasound);
+  // Publish and subscribe to topics
   nh.advertise(pub_encoder);
-  nh.subscribe(s);
+  nh.advertise(pub_rc_inputs);
+  nh.advertise(pub_ultrasound);
+  nh.subscribe(sub_ecu);
 
   // Arming ESC, 1 sec delay for arming and ROS
-  motor.write(theta_center);
-  steering.write(theta_center);
-  delay(1000);
+  car.armActuators();
   t0 = millis();
 
 }
@@ -132,20 +213,24 @@ void setup()
 /**************************************************************************
 ARDUINO MAIN lOOP
 **************************************************************************/
-void loop()
-{
-    // compute time elapsed (in ms)
+void loop() {
+  // compute time elapsed (in ms)
   dt = millis() - t0;
 
-  // publish measurements
   if (dt > 50) {
-    // publish encodeer measurement
+    car.readAndCopyInputs();
 
-    encoder.FL = FL_count;
-    encoder.FR = FR_count;
-    encoder.BL = 0;
-    encoder.BR = 0;
+    // TODO make encoder and rc_inputs private properties on car? Then
+    // car.publishEncoder(); and car.publishRCInputs();
+    encoder.FL = car.getEncoderFL();
+    encoder.FR = car.getEncoderFR();
+    encoder.BL = car.getEncoderBL();
+    encoder.BR = car.getEncoderBR();
     pub_encoder.publish(&encoder);
+
+    rc_inputs.motor_pwm = car.getRCThrottle();
+    rc_inputs.servo_pwm = car.getRCSteering();
+    pub_rc_inputs.publish(&rc_inputs);
 
     // publish ultra-sound measurement
     /*
@@ -153,8 +238,8 @@ void loop()
     ultrasound.back = us_bk.getRange();
     ultrasound.right = us_rt.getRange();
     ultrasound.left = us_lt.getRange();
-    */
     pub_ultrasound.publish(&ultrasound);
+    */
     t0 = millis();
   }
 
@@ -162,40 +247,166 @@ void loop()
 }
 
 /**************************************************************************
-ENCODER COUNTERS
+CAR CLASS IMPLEMENTATION
 **************************************************************************/
-// increment the counters
-void FL_inc() { FL_count++; }
-void FR_inc() { FR_count++; }
+float Car::saturateMotor(float x) {
+  if (x  == noAction ){ return MOTOR_NEUTRAL; }
 
-/**************************************************************************
-SATURATE MOTOR AND SERVO COMMANDS
-**************************************************************************/
-int saturateMotor(int x)
-{
-  if (x  == noAction ){ return motor_neutral; }
-
-  if (x  >  motor_max) {
-    x = motor_max;
-  }
-  else if (x < motor_min) {
-    x = motor_min;
+  if (x  >  MOTOR_MAX) {
+    x = MOTOR_MAX;
+  } else if (x < MOTOR_MIN) {
+    x = MOTOR_MIN;
   }
   return x;
 }
 
-int saturateServo(int x)
-{
-
-  if (x  == noAction ){
-    return theta_center;
+float Car::saturateServo(float x) {
+  if (x  == noAction ) {
+    return THETA_CENTER;
   }
 
-  if (x  >  theta_max) {
-    x = theta_max;
+  if (x  >  THETA_MAX) {
+    x = THETA_MAX;
   }
-  else if (x < theta_min) {
-    x = theta_min;
+  else if (x < THETA_MIN) {
+    x = THETA_MIN;
   }
   return x;
+}
+
+void Car::initEncoders() {
+  /* pinMode(ENC_FR_PIN, INPUT_PULLUP); */
+  pinMode(ENC_FL_PIN, INPUT_PULLUP);
+  pinMode(ENC_BR_PIN, INPUT_PULLUP);
+  pinMode(ENC_BL_PIN, INPUT_PULLUP);
+  /* enableInterrupt(ENC_FR_PIN, incFRCallback, CHANGE); */
+  enableInterrupt(ENC_FL_PIN, incFLCallback, CHANGE);
+  enableInterrupt(ENC_BR_PIN, incBRCallback, CHANGE);
+  enableInterrupt(ENC_BL_PIN, incBLCallback, CHANGE);
+}
+
+void Car::initRCInput() {
+  pinMode(THROTTLE_PIN, INPUT_PULLUP);
+  pinMode(STEERING_PIN, INPUT_PULLUP);
+  enableInterrupt(THROTTLE_PIN, calcThrottleCallback, CHANGE);
+  enableInterrupt(STEERING_PIN, calcSteeringCallback, CHANGE);
+}
+
+void Car::initActuators() {
+  motor.attach(MOTOR_PIN);
+  steering.attach(SERVO_PIN);
+}
+
+void Car::armActuators() {
+  motor.write(MOTOR_NEUTRAL);
+  steering.write(THETA_CENTER);
+  delay(1000);
+}
+
+void Car::writeToActuators(const barc::ECU& ecu) {
+  float motorCMD = saturateMotor(ecu.motor_pwm);
+  float servoCMD = saturateServo(ecu.servo_pwm);
+  motor.write(motorCMD);
+  steering.write(servoCMD);
+}
+
+uint8_t Car::microseconds2PWM(uint16_t microseconds) {
+  // Scales RC pulses from 1000 - 2000 microseconds to 0 - 180 PWM angles
+  uint16_t pwm = (microseconds - 1000.0)/1000.0*180;
+  return static_cast<uint8_t>(pwm);
+}
+
+void Car::calcThrottle() {
+  if(digitalRead(THROTTLE_PIN) == HIGH) {
+    // rising edge of the signal pulse, start timing
+    throttleStart = micros();
+  } else {
+    // falling edge, calculate duration of throttle pulse
+    throttleInShared = (uint16_t)(micros() - throttleStart);
+    // set the throttle flag to indicate that a new signal has been received
+    updateFlagsShared |= THROTTLE_FLAG;
+  }
+}
+
+void Car::calcSteering() {
+  if(digitalRead(STEERING_PIN) == HIGH) {
+    steeringStart = micros();
+  } else {
+    steeringInShared = (uint16_t)(micros() - steeringStart);
+    updateFlagsShared |= STEERING_FLAG;
+  }
+}
+
+void Car::incFL() {
+  FL_count_shared++;
+  updateFlagsShared |= FL_FLAG;
+}
+
+void Car::incFR() {
+  FR_count_shared++;
+  updateFlagsShared |= FR_FLAG;
+}
+
+void Car::incBL() {
+  BL_count_shared++;
+  updateFlagsShared |= BL_FLAG;
+}
+
+void Car::incBR() {
+  BR_count_shared++;
+  updateFlagsShared |= BR_FLAG;
+}
+
+void Car::readAndCopyInputs() {
+  // check shared update flags to see if any channels have a new signal
+  if (updateFlagsShared) {
+    // Turn off interrupts, make local copies of variables set by interrupts,
+    // then turn interrupts back on. Without doing this, an interrupt could
+    // update a shared multibyte variable while the loop is in the middle of
+    // reading it
+    noInterrupts();
+    // make local copies
+    updateFlags = updateFlagsShared;
+    if(updateFlags & THROTTLE_FLAG) {
+      throttleIn = throttleInShared;
+    }
+    if(updateFlags & STEERING_FLAG) {
+      steeringIn = steeringInShared;
+    }
+    if(updateFlags & FL_FLAG) {
+      FL_count = FL_count_shared;
+    }
+    if(updateFlags & FR_FLAG) {
+      FR_count = FR_count_shared;
+    }
+    if(updateFlags & BL_FLAG) {
+      BL_count = BL_count_shared;
+    }
+    if(updateFlags & BR_FLAG) {
+      BR_count = BR_count_shared;
+    }
+    // clear shared update flags and turn interrupts back on
+    updateFlagsShared = 0;
+    interrupts();
+  }
+}
+
+uint8_t Car::getRCThrottle() {
+  return microseconds2PWM(throttleIn);
+}
+uint8_t Car::getRCSteering() {
+  return microseconds2PWM(steeringIn);
+}
+
+int Car::getEncoderFL() {
+  return FL_count;
+}
+int Car::getEncoderFR() {
+  return FR_count;
+}
+int Car::getEncoderBL() {
+  return BL_count;
+}
+int Car::getEncoderBR() {
+  return BR_count;
 }

--- a/scripts/install_enable_interrupt.sh
+++ b/scripts/install_enable_interrupt.sh
@@ -1,0 +1,4 @@
+cd ~/sketchbook/libraries
+wget -O enableinterrupt.zip "https://bintray.com/greygnome/generic/download_file?file_path=enableinterrupt-0.9.5.zip"
+unzip enableinterrupt.zip
+rm enableinterrupt.zip

--- a/workspace/src/barc/launch/cruiseControl.launch
+++ b/workspace/src/barc/launch/cruiseControl.launch
@@ -27,13 +27,25 @@
       <param name="r_std" type="double" value="0.1" />
   </node>
 
-  <!-- CONTROLLER -->
+  <!-- LONGITUDINAL CONTROLLER -->
   <node pkg="barc" type="controller_velocity.py" name="controller" output="screen">
     <!-- PID for velocity -->
     <!-- good tuning pid: 0.1 0.01 0.1 -->
     <param name="p" type="double" value="0.1" />
     <param name="i" type="double" value="0.01" />
     <param name="d" type="double" value="0.1" />
+  </node>
+
+  <!-- LATERAL CONTROLLER -->
+  <node pkg="barc" type="controller_yaw.py" name="controller_yaw" output="screen">
+    <!-- PID for yaw using imu gyro -->
+    <!-- good tuning pid: 40 5 0 -->
+    <param name="p" type="double" value="40" />
+    <param name="i" type="double" value="5" />
+    <param name="d" type="double" value="0" />
+
+    <param name="steering_angle" type="int" value="5" />
+
   </node>
 
   <!-- Record the experiment data -->

--- a/workspace/src/barc/launch/cruiseControl.launch
+++ b/workspace/src/barc/launch/cruiseControl.launch
@@ -1,0 +1,43 @@
+<launch>
+  <!-- IMU NODE -->
+  <node pkg="barc" type="imu_data_acquisition.py" name="imu_node" >
+    <param name="port" value="/dev/ttyACM0" />
+  </node>
+
+  <!-- ARDUINO NODE -->
+  <node pkg="rosserial_python" type="serial_node.py" name="arduino_node" >
+    <param name="port" value="/dev/ttyUSB0" />
+  </node>
+
+  <!-- ODROID TO ARDUINO HUB -->
+  <node pkg="barc" type="arduino_interface.py" name="arduino_interface" output="screen">
+  </node>
+
+  <!-- STATE ESTIMATOR -->
+  <node pkg="barc" type="state_estimation_KinBkMdl.py" name="state_estimation" output="screen">
+      <!-- vehicle properties -->
+      <param name="L_a" type="double" value="0.125" />
+      <param name="L_b" type="double" value="0.125" />
+
+      <!-- v_x estimation sample time-->
+      <param name="dt_v_enc" type="double" value="0.2" />
+
+      <!-- ekf properties -->
+      <param name="q_std" type="double" value="0.1" />
+      <param name="r_std" type="double" value="0.1" />
+  </node>
+
+  <!-- CONTROLLER -->
+  <node pkg="barc" type="controller_velocity.py" name="controller" output="screen">
+    <!-- PID for velocity -->
+    <!-- good tuning pid: 0.1 0.01 0.1 -->
+    <param name="p" type="double" value="0.1" />
+    <param name="i" type="double" value="0.01" />
+    <param name="d" type="double" value="0.1" />
+  </node>
+
+  <!-- Record the experiment data -->
+  <!-- <node pkg="rosbag" type="record" name="rosbag_record" args=" -a" /> -->
+
+</launch>
+

--- a/workspace/src/barc/launch/estimation_KinBkMdl.launch
+++ b/workspace/src/barc/launch/estimation_KinBkMdl.launch
@@ -1,7 +1,7 @@
 <launch>
 
-    <!--- 
-    ADD A CONTROLLER 
+    <!---
+    ADD A CONTROLLER
     -->
 
     <!-- IMU NODE -->
@@ -20,9 +20,9 @@
         <!-- vehicle properties -->
         <param name="L_a" type="double" value="0.125" />
         <param name="L_b" type="double" value="0.125" />
-        
+
         <!-- v_x estimation sample time-->
-        <param name="dt_vx" type="double" value="0.2" />
+        <param name="dt_v_enc" type="double" value="0.2" />
 
         <!-- ekf properties -->
         <param name="q_std" type="double" value="0.1" />

--- a/workspace/src/barc/src/arduino_interface.py
+++ b/workspace/src/barc/src/arduino_interface.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# ---------------------------------------------------------------------------
+# Licensing Information: You are free to use or extend these projects for
+# education or reserach purposes provided that (1) you retain this notice
+# and (2) you provide clear attribution to UC Berkeley, including a link
+# to http://barc-project.com
+#
+# Attibution Information: The barc project ROS code-base was developed at UC
+# Berkeley in the Model Predictive Control (MPC) lab by Jon Gonzales
+# (jon.gonzales@berkeley.edu) and Greg Marcil (grmarcil@berkeley.edu). The cloud
+# services integation with ROS was developed by Kiet Lam
+# (kiet.lam@berkeley.edu). The web-server app Dator was based on an open source
+# project by Bruce Wootton
+# ---------------------------------------------------------------------------
+
+# README: This node serves as an outgoing messaging bus from odroid to arduino
+# Subscribes: steering and motor commands on 'servo_pwm' and 'motor_pwm' and
+# Publishes: combined ecu commands as 'ecu'
+
+# Eventually, there should be another node, or this node could be extended, as a
+# central translator between steering angle and desired acceleration to servo
+# and motor pwm. Making the translator a separate node would be nice because
+# this node would be reusable with different translators (in case someone has a
+# controller that outputs something other than desired acceleration, for
+# example). Eg, my cruise controller operates directly on motor cmd
+
+import rospy
+from barc.msg import ECU
+from input_map import angle_2_servo
+
+def motor_callback(msg):
+    global motor_pwm
+    motor_pwm = msg.motor_pwm
+    update_arduino()
+
+def servo_callback(msg):
+    global servo_pwm
+    servo_pwm = msg.servo_pwm
+    update_arduino()
+
+def neutralize():
+    global motor_pwm
+    motor_pwm = 90
+    update_arduino()
+
+def update_arduino():
+    global motor_pwm, servo_cmd, ecu_pub
+    ecu_cmd = ECU(motor_pwm, servo_pwm)
+    ecu_pub.publish(ecu_cmd)
+
+def arduino_interface():
+    global motor_pwm, servo_pwm, ecu_pub
+    # launch node, subscribe to motorPWM and servoPWM, publish ecu
+    rospy.init_node('arduino_interface')
+    rospy.Subscriber('motor_pwm', ECU, motor_callback, queue_size = 10)
+    rospy.Subscriber('servo_pwm', ECU, servo_callback, queue_size = 10)
+    ecu_pub = rospy.Publisher('ecu', ECU, queue_size = 10)
+
+    # initialize motor and servo at neutral
+    motor_pwm = 90
+    steering_angle = 0
+    steering_offset = 2
+    servo_pwm = angle_2_servo(steering_angle - steering_offset)
+
+    # Set motor to neutral on shutdown
+    rospy.on_shutdown(neutralize)
+
+    # process callbacks and keep alive
+    rospy.spin()
+
+#############################################################
+if __name__ == '__main__':
+    try:
+        arduino_interface()
+    except rospy.ROSInterruptException:
+        pass

--- a/workspace/src/barc/src/controller_velocity.py
+++ b/workspace/src/barc/src/controller_velocity.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# ---------------------------------------------------------------------------
+# Licensing Information: You are free to use or extend these projects for
+# education or reserach purposes provided that (1) you retain this notice
+# and (2) you provide clear attribution to UC Berkeley, including a link
+# to http://barc-project.com
+#
+# Attibution Information: The barc project ROS code-base was developed
+# at UC Berkeley in the Model Predictive Control (MPC) lab by Jon Gonzales
+# (jon.gonzales@berkeley.edu). The cloud services integation with ROS was developed
+# by Kiet Lam  (kiet.lam@berkeley.edu). The web-server app Dator was
+# based on an open source project by Bruce Wootton
+# ---------------------------------------------------------------------------
+
+# This controller can be launched with cruiseControl.launch
+# Requires a kinematic state estimator node and an arduino hub node
+
+import rospy
+from barc.msg import ECU, Z_KinBkMdl
+from geometry_msgs.msg import Vector3
+from pid import PID
+
+# Save the latest velocity from the state estimator
+def state_estimate_callback(msg):
+    global v_est
+    v_est = msg.v
+
+# Change the controller's reference velocity as commanded
+# Currently do this from the command line with `rostopic pub -1 ...`
+# but this could be used with another controller that publishes desired velocity
+def v_ref_callback(msg):
+    global pid
+    pid.setPoint(msg.x)
+
+#############################################################
+def control_velocity():
+    global pid, v_est
+
+    rospy.init_node('controller_velocity')
+
+    motor_pub = rospy.Publisher('motor_pwm', ECU, queue_size = 10)
+    rospy.Subscriber('v_ref', Vector3, v_ref_callback, queue_size=10)
+    rospy.Subscriber('state_estimate', Z_KinBkMdl, state_estimate_callback, queue_size=10)
+
+    # set node rate
+    rateHz  = 50
+    dt      = 1.0 / rateHz
+    rate    = rospy.Rate(rateHz)
+
+    # initialize motor_pwm and v_est at neutral
+    v_est = 0
+    motor_pwm = 90
+
+    # use pid to correct velocity, begins with set point at zero
+    p       = rospy.get_param("controller/p")
+    i       = rospy.get_param("controller/i")
+    d       = rospy.get_param("controller/d")
+    pid     = PID(P=p, I=i, D=d)
+
+    # main loop
+    while not rospy.is_shutdown():
+        u = pid.update(v_est, dt)
+
+        motor_pwm = motor_pwm + u
+
+        # send command signal
+        motor_cmd = ECU(motor_pwm, 0)
+        motor_pub.publish(motor_cmd)
+
+        rate.sleep()
+
+#############################################################
+if __name__ == '__main__':
+    try:
+        control_velocity()
+    except rospy.ROSInterruptException:
+        pass

--- a/workspace/src/barc/src/controller_yaw.py
+++ b/workspace/src/barc/src/controller_yaw.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+# ---------------------------------------------------------------------------
+# Licensing Information: You are free to use or extend these projects for
+# education or reserach purposes provided that (1) you retain this notice
+# and (2) you provide clear attribution to UC Berkeley, including a link
+# to http://barc-project.com
+#
+# Attibution Information: The barc project ROS code-base was developed
+# at UC Berkeley in the Model Predictive Control (MPC) lab by Jon Gonzales
+# (jon.gonzales@berkeley.edu). The cloud services integation with ROS was developed
+# by Kiet Lam  (kiet.lam@berkeley.edu). The web-server app Dator was
+# based on an open source project by Bruce Wootton
+# ---------------------------------------------------------------------------
+
+# This controller can be launched with cruiseControl.launch
+# Requires a kinematic state estimator node and an arduino hub node
+
+import rospy
+from barc.msg import ECU
+from data_service.msg import TimeData
+from numpy import unwrap, array
+from input_map import angle_2_servo
+from pid import PID
+
+# pid control for constant yaw angle
+yaw0 = 0
+read_yaw0 = False
+yaw_prev = 0
+yaw = 0
+err = 0
+def imu_callback(data):
+    global yaw0, read_yaw0, yaw_prev, yaw, err
+
+    # eextract yaw angle
+    (_,_,yaw, _,_,_, _,_,_) = data.value
+
+    #save initial measurements
+    if not read_yaw0:
+        read_yaw0 = True
+        yaw0 = yaw
+    else:
+        temp        = unwrap(array([yaw_prev, yaw]))
+        yaw         = temp[1]
+        yaw_prev    = yaw
+
+    err = yaw - yaw0
+
+#############################################################
+def control_yaw():
+
+    rospy.init_node('controller_yaw')
+
+    steering_pub = rospy.Publisher('servo_pwm', ECU, queue_size = 10)
+    rospy.Subscriber('imu', TimeData, imu_callback)
+
+    # set node rate
+    rateHz  = 50
+    dt      = 1.0 / rateHz
+    rate    = rospy.Rate(rateHz)
+
+    str_ang = rospy.get_param("controller_yaw/steering_angle")
+
+    # use pid to correct yaw angle, begins with set point at initial yaw angle
+    p       = rospy.get_param("controller_yaw/p")
+    i       = rospy.get_param("controller_yaw/i")
+    d       = rospy.get_param("controller_yaw/d")
+    pid     = PID(P=p, I=i, D=d)
+
+    # main loop
+    while not rospy.is_shutdown():
+        # get steering wheel command
+        u = pid.update(err, dt)
+        servoCMD = angle_2_servo(u)
+
+        # send command signal
+        ecu_cmd = ECU(0, servoCMD)
+        steering_pub.publish(ecu_cmd)
+
+        #wait
+        rate.sleep()
+
+#############################################################
+if __name__ == '__main__':
+    try:
+        control_yaw()
+    except rospy.ROSInterruptException:
+        pass

--- a/workspace/src/barc/src/pid.py
+++ b/workspace/src/barc/src/pid.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
 # ---------------------------------------------------------------------------
-# Licensing Information: You are free to use or extend these projects for 
+# Licensing Information: You are free to use or extend these projects for
 # education or reserach purposes provided that (1) you retain this notice
-# and (2) you provide clear attribution to UC Berkeley, including a link 
+# and (2) you provide clear attribution to UC Berkeley, including a link
 # to http://barc-project.com
 #
 # Attibution Information: The barc project ROS code-base was developed
 # at UC Berkeley in the Model Predictive Control (MPC) lab by Jon Gonzales
 # (jon.gonzales@berkeley.edu). The cloud services integation with ROS was developed
-# by Kiet Lam  (kiet.lam@berkeley.edu). The web-server app Dator was 
+# by Kiet Lam  (kiet.lam@berkeley.edu). The web-server app Dator was
 # based on an open source project by Bruce Wootton
 # ---------------------------------------------------------------------------
 
@@ -21,21 +21,23 @@ class PID:
 
         self.set_point      = 0             # reference point
         self.e              = 0
-        
+
         self.e_int          = 0
         self.int_e_max      = Integrator_max
         self.int_e_min      = Integrator_min
 
     def update(self,current_value, dt):
+        self.current_value = current_value
+
         e_t         = self.set_point - current_value
         de_t        = ( e_t - self.e)/dt
-        
+
         self.e_int  = self.e_int + e_t * dt
         if self.e_int > self.int_e_max:
             self.e_int = self.int_e_max
         elif self.e_int < self.int_e_min:
             self.e_int = self.int_e_min
-            
+
         P_val  = self.Kp * e_t
         I_val  = self.Ki * self.e_int
         D_val  = self.Kd * de_t
@@ -47,7 +49,10 @@ class PID:
 
     def setPoint(self,set_point):
         self.set_point    = set_point
+        # reset error integrator
         self.e_int        = 0
+        # reset error, otherwise de/dt will skyrocket
+        self.e            = set_point - self.current_value
 
     def setKp(self,P):
         self.Kp=P
@@ -63,27 +68,27 @@ class PID:
 
     def getError(self):
         return self.e
-  
+
 #%% Example function
 def fx(x, u, dt):
     x_next = x +  (3*x + u) * dt
     return x_next
-  
+
 #%% Test script to ensure program is functioning properly
 if __name__ == "__main__":
-    
+
     from numpy import zeros
     import matplotlib.pyplot as plt
-    
+
     n       = 200
     x       = zeros(n)
     x[0]    = 20
     pid     = PID(P=3.7, I=5, D=0.5)
     dt = 0.1
-    
+
     for i in range(n-1):
         u       = pid.update(x[i], dt)
         x[i+1] = fx(x[i],u, dt)
-         
+
     plt.plot(x)
     plt.show()

--- a/workspace/src/barc/src/state_estimation_KinBkMdl.py
+++ b/workspace/src/barc/src/state_estimation_KinBkMdl.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
 # ---------------------------------------------------------------------------
-# Licensing Information: You are free to use or extend these projects for 
+# Licensing Information: You are free to use or extend these projects for
 # education or reserach purposes provided that (1) you retain this notice
-# and (2) you provide clear attribution to UC Berkeley, including a link 
+# and (2) you provide clear attribution to UC Berkeley, including a link
 # to http://barc-project.com
 #
 # Attibution Information: The barc project ROS code-base was developed
 # at UC Berkeley in the Model Predictive Control (MPC) lab by Jon Gonzales
 # (jon.gonzales@berkeley.edu). The cloud services integation with ROS was developed
-# by Kiet Lam  (kiet.lam@berkeley.edu). The web-server app Dator was 
+# by Kiet Lam  (kiet.lam@berkeley.edu). The web-server app Dator was
 # based on an open source project by Bruce Wootton
 # ---------------------------------------------------------------------------
 
@@ -27,7 +27,7 @@ from rospy_tutorials.msg import Floats
 from rospy.numpy_msg import numpy_msg
 
 # input variables [default values]
-d_f 	    = 0         # steering angle [deg]
+d_f         = 0         # steering angle [deg]
 a           = 0         # acceleration [m/s]
 servo_pwm   = 90
 motor_pwm   = 90
@@ -36,98 +36,136 @@ motor_pwm   = 90
 (roll, pitch, yaw, a_x, a_y, a_z, w_x, w_y, w_z) = zeros(9)
 yaw_prev    = 0
 psi         = 0
+psi_meas    = 0
 
 # from encoder
-v 	        = 0
-t0 	        = time.time()
-n_FL	    = 0                     # counts in the front left tire
-n_FR 	    = 0                     # counts in the front right tire
-n_FL_prev 	= 0
-n_FR_prev 	= 0
-r_tire 		= 0.04                  # radius from tire center to perimeter along magnets [m]
-dx_qrt 	    = 2.0*pi*r_tire/4.0     # distance along quarter tire edge [m]
+v           = 0
+v_meas      = 0
+t0          = time.time()
+n_FL        = 0                     # counts in the front left tire
+n_FR        = 0                     # counts in the front right tire
+n_BL        = 0                     # counts in the back left tire
+n_BR        = 0                     # counts in the back right tire
+n_FL_prev   = 0
+n_FR_prev   = 0
+n_BL_prev   = 0
+n_BR_prev   = 0
+r_tire      = 0.036                  # radius from tire center to perimeter along magnets [m]
+dx_qrt      = 2.0*pi*r_tire/4.0     # distance along quarter tire edge [m]
 
 # ecu command update
 def ecu_callback(data):
-    global motor_pwm, servo_pwm, d_f, a
-    motor_pwm	    = data.motor_pwm
+    global motor_pwm, servo_pwm, d_f, a, v_meas
+    motor_pwm       = data.motor_pwm
     servo_pwm       = data.servo_pwm
     d_f             = servo_2_angle(servo_pwm) * pi/180         # [rad]
 
+    # saturate
+    if motor_pwm > 120:
+        motor_pwm = 120
+    elif motor_pwm < 40:
+        motor_pwm = 40
+
     # apply acceleration input
-    if a > 95:
-        a           = 0.3*(motor_pwm - 95)                          # TODO: need to build correct mapping
+
+    # TODO: build a correct mapping
+    # TODO: refactor ECU messages to (accel, angle) rather than (motor_pwm,
+    # servo_pwm) so that this conversion back and forth can happen in a
+    # centralized place (probably arduino code but an argument could be made
+    # for doing this on a barc/inputs message which a python node listens
+    # to, converts, and publishes barc/ECU
+    if motor_pwm > 94:
+        a = 0.23*(motor_pwm - 94)
+    elif motor_pwm < 87:
+        a = -0.1*(87 - motor_pwm)
+    elif motor_pwm > 91:
+        a = 0.23
+    elif motor_pwm < 89:
+        a = -0.1
     else:
-        a           = 0
+        a = 0
 
 # imu measurement update
 def imu_callback(data):
     # units: [rad] and [rad/s]
     global roll, pitch, yaw, a_x, a_y, a_z, w_x, w_y, w_z
-    global yaw_prev, psi
+    global yaw_prev, psi_meas
     (roll, pitch, yaw, a_x, a_y, a_z, w_x, w_y, w_z) = data.value
     # unwrap angle measurements, since measurements wrap at plus/minus pi
     yaw         = unwrap(array([yaw_prev, yaw]), discont = 2*pi)[1]
     yaw_prev    = yaw
-    psi         = yaw
+    psi_meas    = yaw
 
 # encoder measurement update
 def enc_callback(data):
-	global v, d_f, t0
-	global n_FL, n_FR, n_FL_prev, n_FR_prev
+    global v, t0, dt_v_enc, v_meas
+    global n_FL, n_FR, n_FL_prev, n_FR_prev
+    global n_BL, n_BR, n_BL_prev, n_BR_prev
 
-	n_FL = data.FL
-	n_FR = data.FR
+    n_FL = data.FL
+    n_FR = data.FR
+    n_BL = data.BL
+    n_BR = data.BR
 
-	# compute time elapsed
-	tf = time.time()
-	dt = tf - t0
-	
-	# if enough time elapse has elapsed, estimate v_x
-	dt_min = 0.20
-	if dt >= dt_min:
-		# compute speed :  speed = distance / time
-		v_FL = float(n_FL- n_FL_prev)*dx_qrt/dt
-		v_FR = float(n_FR- n_FR_prev)*dx_qrt/dt
-		v 	 = (v_FL + v_FR)/2.0
+    # compute time elapsed
+    tf = time.time()
+    dt = tf - t0
 
-		# update old data
-		n_FL_prev   = n_FL
-		n_FR_prev   = n_FR
-		t0 	        = time.time()
+    # if enough time elapse has elapsed, estimate v_x
+    if dt >= dt_v_enc:
+        # compute speed :  speed = distance / time
+        v_FL = float(n_FL - n_FL_prev)*dx_qrt/dt
+        v_FR = float(n_FR - n_FR_prev)*dx_qrt/dt
+        v_BL = float(n_BL - n_BL_prev)*dx_qrt/dt
+        v_BR = float(n_BR - n_BR_prev)*dx_qrt/dt
+        # Uncomment/modify according to your encoder setup
+        # v_meas    = (v_FL + v_FR)/2.0
+        # Modification for 3 working encoders
+        v_meas = (v_FL + v_BL + v_BR)/3.0
+        # Modification for bench testing (driven wheels only)
+        # v = (v_BL + v_BR)/2.0
+
+        # update old data
+        n_FL_prev   = n_FL
+        n_FR_prev   = n_FR
+        n_BL_prev   = n_BL
+        n_BR_prev   = n_BR
+        t0          = time.time()
 
 
 # state estimation node
 def state_estimation():
-	# initialize node
+    global dt_v_enc
+    global v_meas, psi_meas
+    # initialize node
     rospy.init_node('state_estimation', anonymous=True)
 
     # topic subscriptions / publications
     rospy.Subscriber('imu', TimeData, imu_callback)
     rospy.Subscriber('encoder', Encoder, enc_callback)
     rospy.Subscriber('ecu', ECU, ecu_callback)
-    state_pub 	= rospy.Publisher('state_estimate', Z_KinBkMdl, queue_size = 10)
+    state_pub   = rospy.Publisher('state_estimate', Z_KinBkMdl, queue_size = 10)
 
-	# get vehicle dimension parameters
+    # get vehicle dimension parameters
     L_a = rospy.get_param("state_estimation/L_a")       # distance from CoG to front axel
     L_b = rospy.get_param("state_estimation/L_b")       # distance from CoG to rear axel
     vhMdl   = (L_a, L_b)
 
     # get encoder parameters
-    dt_vx   = rospy.get_param("state_estimation/dt_vx")     # time interval to compute v_x
+    dt_v_enc = rospy.get_param("state_estimation/dt_v_enc") # time interval to compute v_x from encoders
 
     # get EKF observer properties
     q_std   = rospy.get_param("state_estimation/q_std")             # std of process noise
     r_std   = rospy.get_param("state_estimation/r_std")             # std of measurementnoise
 
-	# set node rate
-    loop_rate 	= 50
-    dt 		    = 1.0 / loop_rate
-    rate 		= rospy.Rate(loop_rate)
-    t0 			= time.time()
+    # set node rate
+    loop_rate   = 50
+    dt          = 1.0 / loop_rate
+    rate        = rospy.Rate(loop_rate)
+    t0          = time.time()
 
     # estimation variables for Luemberger observer
-    z_EKF       = zeros(4) 
+    z_EKF       = zeros(4)
 
     # estimation variables for EKF
     P           = eye(4)                # initial dynamics coveriance matrix
@@ -136,26 +174,26 @@ def state_estimation():
 
     while not rospy.is_shutdown():
 
-		# publish state estimate
-        (x, y, psi, v) = z_EKF          
+        # publish state estimate
+        (x, y, psi, v) = z_EKF
 
         # publish information
         state_pub.publish( Z_KinBkMdl(x, y, psi, v) )
 
         # collect measurements, inputs, system properties
         # collect inputs
-        y   = array([psi, v])
+        y   = array([psi_meas, v_meas])
         u   = array([ d_f, a ])
-        args = (u,vhMdl,dt) 
+        args = (u,vhMdl,dt)
 
         # apply EKF and get each state estimate
         (z_EKF,P) = ekf(f_KinBkMdl, z_EKF, P, h_KinBkMdl, y, Q, R, args )
 
-		# wait
+        # wait
         rate.sleep()
 
 if __name__ == '__main__':
-	try:
-	   state_estimation()
-	except rospy.ROSInterruptException:
-		pass
+    try:
+       state_estimation()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
This branch contributes

1. Refactored arduino code (improved readability of loop() and setup() routines). Would like to refactor Car class into .cpp and .h files to #include but can't figure out how to with the existing arduino compilation process.
2. Arduino support for all four encoders via the EnableInterrupt library
3. Arduino support for using the remote control (will publish several examples for using this functionality in python code in separate PR)
4. Installation script for EnableInterrupt library
5. The creation of an arduino_interface.py node. This node listens to steering and motor pwm topics (separately, to allow a lateral and longitudinal controller to run independently) and publishes to the ecu topic. This node could be coupled with a (steering angle, acceleration) -> (servo pwm, throttle pwm) translator node in the future to fully decouple the controllers from low level details.
6. The creation of a cruise control node and associated launch file to demonstrate the use of the arduino_interface.py node.
